### PR TITLE
Allow medium-zoom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,29 @@ This plugin uses the [`medium-zoom`](https://github.com/francoischalifour/medium
 
 ## Install and Configure
 
-* npm install flexanalytics/plugin-image-zoom
-* Add as a plugin to `docusaurus.config.js`, like this:
-``` js
+- npm install flexanalytics/plugin-image-zoom
+- Add as a plugin to `docusaurus.config.js`, like this:
+
+```js
   plugins: [
     'plugin-image-zoom'
   ],
 ```
-* Set the zoomSelector (optional, defaults to '.markdown img') in `docusaurus.config.js`, like this:
-``` js
+
+- Set the zoomSelector (optional, defaults to '.markdown img') in `docusaurus.config.js`, like this:
+
+```js
   themeConfig: {
-    zoomSelector: '.markdown img',
+    imageZoom: {
+      selector: '.markdown img',
+      options: {
+        margin: 24,
+        background: '#BADA55',
+        scrollOffset: 0,
+        container: '#zoom-container',
+        template: '#zoom-template',
+      },
+    }
   },
 ```
 
@@ -25,17 +37,18 @@ This plugin uses the [`medium-zoom`](https://github.com/francoischalifour/medium
 If you want to exclude certain images from using the zoom, then you'll need to apply a special tag to the image in your markdown and then use the `zoomSelector` option in `themeConfig` to exclude that tag.
 
 For example, in your markdown you could wrap the image in an `<em>` tag, as such:
-``` md
-click on the *![](/img/portal/new.png)* button...
+
+```md
+click on the _![](/img/portal/new.png)_ button...
 ```
 
 Then, exclude images inside an `<em>` tag, as such:
-``` js
+
+```js
   themeConfig: {
     zoomSelector: '.markdown :not(em) > img',
   },
 ```
-
 
 ## See `plugin-image-zoom` in action
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This plugin uses the [`medium-zoom`](https://github.com/francoischalifour/medium
         container: '#zoom-container',
         template: '#zoom-template',
       },
-    }
+    },
   },
 ```
 
@@ -49,7 +49,9 @@ Then, exclude images inside an `<em>` tag, as such:
 
 ```js
   themeConfig: {
-    zoomSelector: '.markdown :not(em) > img',
+    imageZoom: {
+      selector: '.markdown :not(em) > img',
+    },
   },
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ This plugin uses the [`medium-zoom`](https://github.com/francoischalifour/medium
   ],
 ```
 
-- Set the zoomSelector (optional, defaults to '.markdown img') in `docusaurus.config.js`, like this:
+- Configure the plugin in `docusaurus.config.js`, like this:
 
 ```js
   themeConfig: {
     imageZoom: {
+      // CSS selector to apply the plugin to, defaults to '.markdown img'
       selector: '.markdown img',
+      // Optional medium-zoom options
+      // see: https://www.npmjs.com/package/medium-zoom#options
       options: {
         margin: 24,
         background: '#BADA55',
@@ -34,7 +37,7 @@ This plugin uses the [`medium-zoom`](https://github.com/francoischalifour/medium
 
 ## Excluding Images from using Zoom
 
-If you want to exclude certain images from using the zoom, then you'll need to apply a special tag to the image in your markdown and then use the `zoomSelector` option in `themeConfig` to exclude that tag.
+If you want to exclude certain images from using the zoom, then you'll need to apply a special tag to the image in your markdown and then use the `imageZoom.selector` option in `themeConfig` to exclude that tag.
 
 For example, in your markdown you could wrap the image in an `<em>` tag, as such:
 

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -17,12 +17,12 @@ export default (function () {
   }
 
   // Backwards compatibility
-  const { zoomSelector } = themeConfig;
+  const { zoomSelector = '.markdown img' } = themeConfig;
   const {
     imageZoom: {
-      selector = zoomSelector || '.markdown img',
+      selector = zoomSelector,
       options,
-    }
+    } = {},
   } = themeConfig;
 
   setTimeout(() => {

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -16,10 +16,17 @@ export default (function () {
     return null;
   }
 
-  const selector = (themeConfig&&themeConfig.zoomSelector) || '.markdown img';
+  // Backwards compatibility
+  const { zoomSelector } = themeConfig;
+  const {
+    imageZoom: {
+      selector = zoomSelector || '.markdown img',
+      options,
+    }
+  } = themeConfig;
 
   setTimeout(() => {
-    mediumZoom(selector);
+    mediumZoom(selector, options);
   }, 1000);
 
 
@@ -31,7 +38,7 @@ export default (function () {
       }
 
       setTimeout(() => {
-        mediumZoom(selector);
+        mediumZoom(selector, options);
       }, 1000);
 
     },

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -18,6 +18,8 @@ export default (function () {
 
   // Backwards compatibility
   const { zoomSelector = '.markdown img' } = themeConfig;
+
+  // Allow medium-zoom options: https://www.npmjs.com/package/medium-zoom#options
   const {
     imageZoom: {
       selector = zoomSelector,


### PR DESCRIPTION
This allows to configure [`medium-zoom` options](https://www.npmjs.com/package/medium-zoom#options) in the Docusaurus configuration and pass them down to the wrapped module.

I have updated the README with the new configuration, but I've made sure to remain backwards compatible with the `zoomSelector` option.